### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mjagbeke/325de1a0-6ff7-45eb-9e37-44dfe6392dea/5ef709b2-624f-4b4d-849b-2c774ab3d649/_apis/work/boardbadge/c90c23e6-d172-4379-8d2c-7f9642c65388)](https://dev.azure.com/mjagbeke/325de1a0-6ff7-45eb-9e37-44dfe6392dea/_boards/board/t/5ef709b2-624f-4b4d-849b-2c774ab3d649/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mjagbeke/325de1a0-6ff7-45eb-9e37-44dfe6392dea/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.